### PR TITLE
Remove use of sudo

### DIFF
--- a/asos.sh
+++ b/asos.sh
@@ -90,7 +90,8 @@ untar_sos_files(){
     do 
     if [ ! -d $file ]
     then
-	tar xf $file.tar.xz
+	tar xf $file.tar.xz --no-same-permissions
+	find $file -type d -exec chmod 0755 {} \;
 	# Removing /var/log/tower/ files older than 5 days
 	find $file/var/log/tower -mtime +5 -delete 2>/dev/null
     fi
@@ -115,7 +116,7 @@ do
                 for file in "${tar_files[@]}"
                 do
 		    printf '%s\n'" ${BOLD}Removing directory: $file${NC}"'%s\n'
-		    sudo rm --interactive=once -rf ${file}
+		    rm --interactive=once -rf ${file}
 		done
 		exit;;
             -cl) # Display output from ./sos_commands/tower/awx-manage_check_license_--data


### PR DESCRIPTION
sosreports will be extracted using the user's umask and will adjust the permissions on the directories within the extraction. By default some of the `/proc` and `/sys` directories have 0444 permissions. Overall this commit removes sudo which hopefully make this a little safer to use.